### PR TITLE
Drop 32-bit support.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,6 @@
-BIT = 32
-ifeq ($(BIT),32)
-	GCC_FLAG = -m32 -Os -ffunction-sections -fdata-sections -s -w -std=c11
-	ICO_FLAG = -F pe-i386
-else
-	GCC_FLAG = -Os -ffunction-sections -fdata-sections -s -w -std=c11
-	ICO_FLAG = 
-endif
+BIT = 64
+GCC_FLAG = -Os -ffunction-sections -fdata-sections -s -w -std=c11
+ICO_FLAG = 
 
 windows: cabbage.exe cabbagew.exe
 	@echo Done.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is the official repository of Cabbagelang Programming Language.
 
 ### Attention!
 
-- If you are on 64-bit system, you have to change `BIT` in `Makefile` to 64.
+- We have dropped 32-bit systems officially. If you are on one, please upgrade to a 64-bit system.
 
 ## Dependences
 


### PR DESCRIPTION
As Windows 11 is only 64-bit and Windows 10 support ends October 2025, I think it's time to end 32-bit support once and for all.